### PR TITLE
TER-158 Collect entity dependencies

### DIFF
--- a/tfconfig/module.go
+++ b/tfconfig/module.go
@@ -165,6 +165,10 @@ func buildAttributePath(tokens ...string) string {
 	return strings.Join(tokens, AttributePathSeparator)
 }
 
+func (r ResourceAttributeReference) Root() string {
+	return buildAttributePath(r.ResourceType, r.ResourceName)
+}
+
 func (r ResourceAttributeReference) Attribute() string {
 	return buildAttributePath(r.ResourceType, r.Path())
 }

--- a/tfconfig/module_call.go
+++ b/tfconfig/module_call.go
@@ -19,5 +19,12 @@ type ModuleCall struct {
 	// }
 	Inputs map[string]AttributeReference `json:"inputs"`
 
+	// All references (not resolved) to other variables (e.g. modules, variables) grouped by name.
+	// This may include variables that themselves do not resolve into attribute value (e.g. if condition).
+	// module "mod" {
+	//	input-name = var.variable_ref != "" ? module.mod.out_ref : other_res.attr
+	// }
+	Dependencies map[string]AttributeReference `json:"dependencies"`
+
 	Module *Module `json:"-"`
 }

--- a/tfconfig/output.go
+++ b/tfconfig/output.go
@@ -10,7 +10,13 @@ type Output struct {
 	Value       ResourceAttributeReference `json:"value"`
 	Description string                     `json:"description,omitempty"`
 	Sensitive   bool                       `json:"sensitive,omitempty"`
-	Pos         SourcePos                  `json:"pos"`
+	Pos         SourcePos                  `json:"pos"` // All references (not resolved) to other variables (e.g. modules, variables) grouped by name.
+
+	// This may include variables that themselves do not resolve into attribute value (e.g. if condition).
+	// module "mod" {
+	//	input-name = var.variable_ref != "" ? module.mod.out_ref : other_res.attr
+	// }
+	Dependencies map[string]AttributeReference `json:"dependencies"`
 }
 
 func (v Output) GetName() string {

--- a/tfconfig/resource.go
+++ b/tfconfig/resource.go
@@ -26,6 +26,13 @@ type Resource struct {
 	// All references to this resource's attributes by other resoures.
 	References map[string][]AttributeReference `json:"references"`
 
+	// All references (not resolved) to other variables (e.g. modules, variables) grouped by name.
+	// This may include variables that themselves do not resolve into attribute value (e.g. if condition).
+	// module "mod" {
+	//	input-name = var.variable_ref != "" ? module.mod.out_ref : other_res.attr
+	// }
+	Dependencies map[string]AttributeReference `json:"dependencies"`
+
 	Pos SourcePos `json:"pos"`
 }
 


### PR DESCRIPTION
For each entity like Resource, ModuleCall and output collect a set of unique dependencies - i.e. references to other variables, modules and resources.

This can be used to determine whcih other entities from within the module a given entity depends on.