### PR TITLE
TER-193 Add position metadata to provider blocks

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -376,10 +376,14 @@ func LoadModuleFromFile(file *hcl.File, mod *Module, resolvedModuleRefs *Resolve
 			diags = append(diags, contentDiags...)
 
 			name := block.Labels[0]
+			srcBlkPos := sourceBlockHCL(block)
 			// Even if there isn't an explicit version required, we still
 			// need an entry in our map to signal the unversioned dependency.
 			if _, exists := mod.RequiredProviders[name]; !exists {
-				mod.RequiredProviders[name] = &ProviderRequirement{}
+				mod.RequiredProviders[name] = &ProviderRequirement{
+					ParentPos: nil, // this is a standalone provider configuration
+					Pos:       srcBlkPos,
+				}
 			}
 			if attr, defined := content.Attributes["version"]; defined {
 				var version string
@@ -403,6 +407,7 @@ func LoadModuleFromFile(file *hcl.File, mod *Module, resolvedModuleRefs *Resolve
 			mod.ProviderConfigs[providerKey] = &ProviderConfig{
 				Name:  name,
 				Alias: alias,
+				Pos:   srcBlkPos,
 			}
 
 		case "resource", "data":

--- a/tfconfig/module.go
+++ b/tfconfig/module.go
@@ -200,6 +200,8 @@ func (r *ResourceAttributeReference) CopyValues(other ResourceAttributeReference
 type ProviderConfig struct {
 	Name  string `json:"name"`
 	Alias string `json:"alias,omitempty"`
+
+	Pos SourcePos `json:"pos"`
 }
 
 // NewModule creates new Module representing Terraform module at the given path


### PR DESCRIPTION
Add position to provider requirements and configurations. The requirements have position (of each individual requirement declaration) and also position of the parent block. If the requirement is implicit (i.e. not declared within required_providers but instead implied from the provider configuration) the parent position is nil.

The provider configuration block has its own position as well.